### PR TITLE
Fixes issue where alertExpiration is expressed as an Int

### DIFF
--- a/graphql/base.schema.graphql
+++ b/graphql/base.schema.graphql
@@ -213,7 +213,7 @@ type ThemePreferences {
 }
 
 type UserPreferences {
-  alertExpiration: Int
+  alertExpiration: Float
   alertPersistence: Boolean
   alerts: [String]
   animation: Boolean


### PR DESCRIPTION
Causes the following issue:

![image](https://user-images.githubusercontent.com/22667297/77450414-6e466400-6db0-11ea-9ce5-d054351108f7.png)
