### PR TITLE
Source ids in query settings input

### DIFF
--- a/atoms/input/autocomplete.tsx
+++ b/atoms/input/autocomplete.tsx
@@ -36,7 +36,12 @@ const useStyles = makeStyles(theme => ({
     flexWrap: 'wrap',
     flex: 1,
     alignItems: 'center',
-    overflow: 'hidden',
+    overflowX: 'scroll',
+    overflowY: 'hidden',
+    '&::-webkit-scrollbar': {
+      display: 'none',
+    },
+    scrollbarWidth: 'none',
   },
   chip: {
     margin: theme.spacing(0.5, 0.25),
@@ -219,6 +224,7 @@ export const WrappedCreatableSelect = (props: CreatableProps<any>) => {
       '& input': {
         font: 'inherit',
       },
+      overflowX: 'scroll',
     }),
   }
   const { label, styles, ...baseProps } = props
@@ -227,9 +233,7 @@ export const WrappedCreatableSelect = (props: CreatableProps<any>) => {
     <CreateableSelect
       components={components}
       classes={classes}
-      styles={{
-        ...selectStyles,
-      }}
+      styles={selectStyles}
       TextFieldProps={{
         label,
         InputLabelProps: {

--- a/graphql/base.schema.graphql
+++ b/graphql/base.schema.graphql
@@ -20,7 +20,7 @@ type QuerySort {
 }
 
 input QuerySettingsInput {
-  src: String
+  sourceIds: [String]
   federation: String
   phonetics: Boolean
   sorts: [QuerySortInput]

--- a/graphql/graphql.js
+++ b/graphql/graphql.js
@@ -292,7 +292,7 @@ const defaultAttributesToNull = (metacard, properties) => {
 export const CACHE_DEFAULTS = {
   getDefaultCache: () => {
     return new InMemoryCache({
-      dataIdFromObject: this.dataIdFromObject,
+      dataIdFromObject: CACHE_DEFAULTS.dataIdFromObject,
     })
   },
   dataIdFromObject: object => {

--- a/graphql/graphql.js
+++ b/graphql/graphql.js
@@ -289,11 +289,10 @@ const defaultAttributesToNull = (metacard, properties) => {
   })
 }
 
-
 export const CACHE_DEFAULTS = {
   getDefaultCache: () => {
     return new InMemoryCache({
-      dataIdFromObject: this.dataIdFromObject
+      dataIdFromObject: this.dataIdFromObject,
     })
   },
   dataIdFromObject: object => {
@@ -306,6 +305,7 @@ export const CACHE_DEFAULTS = {
       default:
         return defaultDataIdFromObject(object)
     }
+  },
 }
 
 export const createClient = (schema, resolvers, cache) => {


### PR DESCRIPTION
Fixes cache default reference and changes query settings input src to match RPC endpoint of sourceIds